### PR TITLE
fix: require that c32 addresses start with `S`

### DIFF
--- a/src/address.ts
+++ b/src/address.ts
@@ -52,6 +52,9 @@ export function c32addressDecode(c32addr: string) : [number, string] {
   if (c32addr.length <= 5) {
     throw new Error('Invalid c32 address: invalid length')
   }
+  if (c32addr[0] != 'S') {
+    throw new Error('Invalid c32 address: must start with "S"')
+  }
   return c32checkDecode(c32addr.slice(1))
 }
 

--- a/tests/unitTests/src/index.ts
+++ b/tests/unitTests/src/index.ts
@@ -555,7 +555,8 @@ export function c32addressTests() {
       () => c32addressDecode('ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQYAC0RQ0'),
       () => c32addressDecode('ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQYAC0RR'),
       () => c32addressDecode('ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQYAC0R'),
-      () => c32addressDecode('ST2J')
+      () => c32addressDecode('ST2J'),
+      () => c32addressDecode('bP2CT665Q0JB7P39TZ7BST0QYCAQSMJWBZK8QT35J')
     ]
 
     t.plan(invalids.length + invalidDecodes.length)


### PR DESCRIPTION
Right now, `c32addressDecode()` will decode the address `bP2CT665Q0JB7P39TZ7BST0QYCAQSMJWBZK8QT35J`.  Given that clients of this library are expecting that this method _not_ decode _invalid_ Stacks addresses, this method should be fixed to require that the leading character is `S`.  This PR addresses this.  Context: https://github.com/blockstack/stacks-utils/issues/21